### PR TITLE
Logging versions down to 0.1 appear to work

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,3 @@
-julia 0.5
-
-Logging 0.3.1
+Logging 0.1
 
 Ipopt


### PR DESCRIPTION
and `julia` is redundant in `test/REQUIRE` if the version isn't any stricter than it is in `REQUIRE`

tested this via
```
Pkg.clone("https://github.com/lanl-ansi/PowerModelsAnnex.jl")
Pkg.add("Logging")
Pkg.pin("Logging", v"0.1.0")
Pkg.test("PowerModelsAnnex")
Pkg.free("Logging")
```
and it worked fine on Julia 0.5. Lower versions of Logging do not load on Julia 0.5.