### PR TITLE
Add empty keys for shunt and storage

### DIFF
--- a/src/frontend/frontend.jl
+++ b/src/frontend/frontend.jl
@@ -1285,6 +1285,9 @@ function network2pmc(
         )
     end
     outnet["load"] = load_dict
+    # Add extra keys that `Network` does not have. These are simply placeholders
+    outnet["shunt"] = Dict{String,Any}()
+    outnet["storage"] = Dict{String,Any}()
     return outnet
 end
 

--- a/test/frontend/frontend.jl
+++ b/test/frontend/frontend.jl
@@ -113,7 +113,9 @@ end
     @test PMA.pmc(net)["branch"]["1"]["rate_a"] == 0.5 * old_rate
     pm = PMA.network2pmc(net)
     @test isa(pm, Dict)
-    @test "branch" in keys(pm)
+    for k in ["branch", "gen", "load", "shunt", "storage", "bus"]
+        @test k in keys(pm)
+    end
     PMA.applyunits!(net)
     @test isa(net.pi_load[:load_p], Array{Union{<:Unitful.Quantity, Missings.Missing}})
     PMA.stripunits!(net)


### PR DESCRIPTION
Solving #35 
Note that `Network` does not really carry data on those structures, so all this does is add empty keys such that computations don't break.

@mjamei19