### PR TITLE
Change DC power flow variables to only include "from" arcs

### DIFF
--- a/src/model/dc-opf.jl
+++ b/src/model/dc-opf.jl
@@ -67,7 +67,7 @@ set_optimizer_attribute(model, "print_level", 0)
 @variable(model, ref[:gen][i]["pmin"] <= pg[i in keys(ref[:gen])] <= ref[:gen][i]["pmax"])
 
 # Add power flow variables p to represent the active power flow for each branch
-@variable(model, -ref[:branch][l]["rate_a"] <= p[(l,i,j) in ref[:arcs]] <= ref[:branch][l]["rate_a"])
+@variable(model, -ref[:branch][l]["rate_a"] <= p[(l,i,j) in ref[:arcs_from]] <= ref[:branch][l]["rate_a"])
 
 # Build JuMP expressions for the value of p[(l,i,j)] and p[(l,j,i)] on the branches
 p_expr = Dict([((l,i,j), 1.0*p[(l,i,j)]) for (l,i,j) in ref[:arcs_from]])


### PR DESCRIPTION
In the original version of the DC OPF, the code created power flow variables for both the "from" and "to" directions on the lines.
Since the lines are lossless, the later code only uses the "from" direction variables and expresses the flow in the "to" direction as the negative of the "from" flow. This is done using the expressions p_expr. 
The "to" direction power flow variables are never used again, but are assigned some (relatively random) values by the the optimization problem. These variables are also easy to confuse with the p_expr. 
I therefore suggest to only define power flow variables for the "from" direction.